### PR TITLE
Check and fix backend errors

### DIFF
--- a/app.out
+++ b/app.out
@@ -1,0 +1,17 @@
+WARNING:root:Twilio or Redis not available - OTP functionality disabled
+WARNING:root:Flask-RESTX not available - API documentation disabled
+WARNING:root:OpenTelemetry not available - observability disabled
+Starting PDF Tool server with SQLite...
+Initializing database...
+Database tables created successfully!
+Access the frontend at: http://localhost:5000
+Press Ctrl+C to stop the server
+ * Serving Flask app 'app'
+ * Debug mode: off
+INFO:werkzeug:[31m[1mWARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.[0m
+ * Running on all addresses (0.0.0.0)
+ * Running on http://127.0.0.1:5000
+ * Running on http://172.30.0.2:5000
+INFO:werkzeug:[33mPress CTRL+C to quit[0m
+INFO:werkzeug:127.0.0.1 - - [24/Aug/2025 11:47:38] "GET / HTTP/1.1" 200 -
+INFO:werkzeug:127.0.0.1 - - [24/Aug/2025 11:47:47] "[32mGET /task/does-not-exist HTTP/1.1[0m" 302 -

--- a/app.py
+++ b/app.py
@@ -1407,7 +1407,7 @@ def import_drive_file():
 
 @app.route('/api/task-status/<task_id>', methods=['GET'])
 @login_required
-def task_status(task_id):
+def celery_task_status(task_id):
     """Get the status of a Celery task"""
     try:
         from celery.result import AsyncResult

--- a/run.out
+++ b/run.out
@@ -1,0 +1,15 @@
+WARNING:root:Twilio or Redis not available - OTP functionality disabled
+WARNING:root:Flask-RESTX not available - API documentation disabled
+WARNING:root:OpenTelemetry not available - observability disabled
+Starting PDF Tool server with SQLite...
+Initializing database...
+Database tables created successfully!
+Access the frontend at: http://localhost:5000
+Press Ctrl+C to stop the server
+ * Serving Flask app 'app'
+ * Debug mode: off
+INFO:werkzeug:[31m[1mWARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.[0m
+ * Running on all addresses (0.0.0.0)
+ * Running on http://127.0.0.1:5000
+ * Running on http://172.30.0.2:5000
+INFO:werkzeug:[33mPress CTRL+C to quit[0m


### PR DESCRIPTION
Rename `task_status` to `celery_task_status` to fix a duplicate endpoint error preventing the Flask backend from starting.

---
<a href="https://cursor.com/background-agent?bcId=bc-89887df1-42f5-4ded-896c-41b9322d159f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-89887df1-42f5-4ded-896c-41b9322d159f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

